### PR TITLE
Assign sequence to the standard object

### DIFF
--- a/lib/academic_benchmarks/standards/standard.rb
+++ b/lib/academic_benchmarks/standards/standard.rb
@@ -18,6 +18,7 @@ module AcademicBenchmarks
 
       def initialize(data)
         data = data["data"] if data["data"]
+        @seq = data["seq"]
         @guid = data["guid"]
         @grade = attr_to_val_or_nil(Grade, data, "grade")
         @label = data["label"]


### PR DESCRIPTION
The `attr_accessor` for sequence is there, it just isn't being assigned